### PR TITLE
Fix errors in Immersive and Atmospheric HUD scripts

### DIFF
--- a/other-authors/IAH - Immersive Torch.LUA
+++ b/other-authors/IAH - Immersive Torch.LUA
@@ -17,16 +17,16 @@ NMS_MOD_DEFINITION_CONTAINER =
 						{
 							["VALUE_CHANGE_TABLE"] 	= 
 							{
-								{"TorchFoV", "60"}
-								{"TorchDimFoV", "45"}
-								{"InteractionTorchFoV", "60"}
-								{"UndergroundTorchFoV", "50"}
+								{"TorchFoV", "60"},
+								{"TorchDimFoV", "45"},
+								{"InteractionTorchFoV", "60"},
+								{"UndergroundTorchFoV", "50"},
 								{"UndergroundTorchFoVFar", "75"}
 							}
 						}
 					}
-				}	
+				}
 			}
 		}
-	}	
+	}
 }

--- a/other-authors/IAH - No HUD Tracking - No VR Warning.LUA
+++ b/other-authors/IAH - No HUD Tracking - No VR Warning.LUA
@@ -50,7 +50,7 @@ NMS_MOD_DEFINITION_CONTAINER =
 					["EXML_CHANGE_TABLE"] 	=
 					{
 						{
-							["PRECEDING_KEY_WORDS"] = {"HazardHeightmaps", "NMSString0x80"},
+							["PRECEDING_KEY_WORDS"] = "HazardHeightmaps",
 							["VALUE_CHANGE_TABLE"]     =
 							{
 									{"Value", ""}, -- untested, but this section *should* remove all HMD HUD hazard graphics, however Im not sure if I built this part of the .LUA right

--- a/other-authors/IAH - No HUD Tracking - No VR Warning.LUA
+++ b/other-authors/IAH - No HUD Tracking - No VR Warning.LUA
@@ -8,14 +8,14 @@ NMS_MOD_DEFINITION_CONTAINER =
 ["MODIFICATIONS"] 			= 
 	{
 		{
-			["MBIN_CHANGE_TABLE"] 	= 
-			{ 
+			["MBIN_CHANGE_TABLE"] 	=
+			{
 				{
 					["MBIN_FILE_SOURCE"] 	= "GCUIGLOBALS.GLOBAL.MBIN",
-					["EXML_CHANGE_TABLE"] 	= 
+					["EXML_CHANGE_TABLE"] 	=
 					{
 						{
-							["VALUE_CHANGE_TABLE"] 	= 
+							["VALUE_CHANGE_TABLE"] 	=
 							{
 								{"HUDPlayerTrackArrowSize", "0"},	-- this section removes HUD HMD tracking markers
 								{"HUDPlayerTrackArrowSizeMin", "0"},
@@ -43,23 +43,27 @@ NMS_MOD_DEFINITION_CONTAINER =
 								{"ShowOnscreenPredatorMarkers", "False"}	-- this removes the predator markers (showing you that a animal is stalking you)						
 							}
 						}
-					},
+					}
+				},
+				{
+					["MBIN_FILE_SOURCE"] 	= "GCUIGLOBALS.GLOBAL.MBIN",
+					["EXML_CHANGE_TABLE"] 	=
 					{
+						{
 							["PRECEDING_KEY_WORDS"] = {"HazardHeightmaps", "NMSString0x80"},
-							["VALUE_CHANGE_TABLE"]     = 
-								{
+							["VALUE_CHANGE_TABLE"]     =
+							{
 									{"Value", ""}, -- untested, but this section *should* remove all HMD HUD hazard graphics, however Im not sure if I built this part of the .LUA right
 									{"Value", ""},
 									{"Value", ""},
 									{"Value", ""},
 									{"Value", ""},
-									{"Value", ""}									
-								}
+									{"Value", ""}
 							}
 						}
 					}
-				}	
+				}
 			}
 		}
-	}	
+	}
 }

--- a/other-authors/IAH - VR QoL and other Changes.LUA
+++ b/other-authors/IAH - VR QoL and other Changes.LUA
@@ -22,6 +22,8 @@ NMS_MOD_DEFINITION_CONTAINER =
 							}
 						}
 					},
+				},
+				{
 					--
 					-- The following changes are for the new VR Inventory Screen.
 					--


### PR DESCRIPTION
- `IAH - VR QoL and other Changes.LUA`:
  - Galaxy movement speed is no longer skipped by a syntax error
- `IAH - Immersive Torch.LUA`
  - Script loads
- `No HUD Tracking - No VR Warning.LUA`
  - Script loads
  - All hazard graphics slots are now blanked instead of just the first